### PR TITLE
Resizes image correctly on canvas

### DIFF
--- a/website/src/components/canvas/Canvas.jsx
+++ b/website/src/components/canvas/Canvas.jsx
@@ -57,6 +57,7 @@ function Canvas() {
           </span>
         </Paper>
       </Box>
+      <CanvasView />
     </div>
   )
 }

--- a/website/src/components/canvas/CanvasElement.jsx
+++ b/website/src/components/canvas/CanvasElement.jsx
@@ -76,15 +76,18 @@ class CanvasElement extends React.Component {
       },
     };
     return (
-      <Rnd bounds={'parent'} ref={ elem => { this.elemRef = elem; } }
+      <Rnd
+        bounds={'parent'}
+        ref={ elem => { this.elemRef = elem; } }
         {...elemProps}
       >
         <div
           style={{
-            height: '100%',
-            width: '100%',
             backgroundImage: 'url(http://marcoortiztorres.me/images/craftml.png)',
-            backgroundSize: 'cover' }}
+            backgroundSize: '100% 100%',
+            backgroundRepeat: 'no-repeat',
+            height: '100%'
+          }}
         />
       </Rnd>
     );

--- a/website/src/components/canvas/CanvasView.jsx
+++ b/website/src/components/canvas/CanvasView.jsx
@@ -15,9 +15,9 @@ const styles = {
     backgroundImage: 'linear-gradient(to right, #dddddd 1px, transparent 1px), linear-gradient(to bottom, #dddddd 1px, transparent 1px)',
     border: '2px dashed #7e7e7e',
     height: '77.2vh',
-    width: '85vw',
     margin: '1vw 0 1vw 13.5vw',
-    position: 'absolute'
+    position: 'absolute',
+    width: '85vw',
   }
 };
 

--- a/website/src/components/canvas/CanvasView.jsx
+++ b/website/src/components/canvas/CanvasView.jsx
@@ -9,6 +9,17 @@ import * as firebase from 'firebase';
 import CanvasElement from './CanvasElement';
 import { initPositions, updatePosition } from '../../redux/actions/positionsActions';
 
+const styles = {
+  canvas: {
+    backgroundSize: '25px 25px',
+    backgroundImage: 'linear-gradient(to right, #dddddd 1px, transparent 1px), linear-gradient(to bottom, #dddddd 1px, transparent 1px)',
+    border: '2px dashed #7e7e7e',
+    height: '77.2vh',
+    width: '85vw',
+    margin: '1vw 0 1vw 13.5vw',
+    position: 'absolute'
+  }
+};
 
 /**
  * Component for the CanvasView for users to arrange elements on.
@@ -52,13 +63,7 @@ class CanvasView extends React.Component {
       );
     });
     return (
-      <div
-        style={{ border: 'solid',
-          height: '70%',
-          width: '80%',
-          marginLeft: '10%',
-          position: 'absolute' }}
-      >
+      <div style={styles.canvas}>
         { elemDivs }
       </div>
     );

--- a/website/src/components/canvas/Sidebar.jsx
+++ b/website/src/components/canvas/Sidebar.jsx
@@ -3,21 +3,20 @@ import Drawer from 'material-ui/Drawer';
 import MenuItem from 'material-ui/MenuItem';
 
 const styles = {
-  sidebar: {
-    marginTop: 114,
-    width: '10%',
-    backgroundColor: "rgba(1, 1, 1, .06)",
-  },
   listItems: {
     marginTop: 20,
-    }
+  },
+  sidebar: {
+    backgroundColor: 'rgba(1, 1, 1, .06)',
+    marginTop: 114,
+    width: '12vw',
+  },
 };
 
 /**
-  * Gives HTML for a new sidebar creation.
-  * @returns {HTML}   The HTML of a new sidebar.
+  * Gives HTML for options sidebar.
+  * @returns {HTML}   The HTML of a sidebar on the canvas page
   */
-
 export default class Sidebar extends React.Component {
   constructor(props) {
     super(props);
@@ -30,7 +29,7 @@ export default class Sidebar extends React.Component {
                        'Sign Out'];
     this.listItems = this.listObject.map((item)=><MenuItem key={item.toString()} onTouchTap = {this.setClose}>{item}</MenuItem>);
   }
-                                         
+
   render() {
     return (
       <div>
@@ -38,10 +37,9 @@ export default class Sidebar extends React.Component {
                 open= {true}
                 docked={true}
                 openSecondary={false}
-         
         >
         <div style={styles.listItems}>
-        {this.listItems}
+          {this.listItems}
         </div>
         </Drawer>
       </div>


### PR DESCRIPTION
Closes #34 
@IanChar 
```backgroundSize: 'cover'``` scales the image to be as large as possible so that the div area is completely covered, cutting off parts of the image on purpose.

My fix forces the image to be the size of the div with ```backgroundSize: '100% 100%'``` 
which is kind of hacky, bc the imported image gets a bit distorted. Not too big of an issue until the imgs get more complicated but can't figure out a better way for now, unless we somehow append that style ^^^ on click or sth.

SideBar changes mostly fixing / refactoring Sean's code.