### PR TITLE
Changed initial model position when it's added

### DIFF
--- a/website/src/components/canvas/CanvasConstants.jsx
+++ b/website/src/components/canvas/CanvasConstants.jsx
@@ -7,8 +7,8 @@ export const SIDEBAR_BUTTONS = [ADD_ELEMENT_BUTTON, DELETE_ELEMENT_BUTTON];
 
 // Initial element conditions
 export const INIT_POSITION = {
-  'x': 100,
-  'y': 100,
+  'x': 300,
+  'y': 50,
 };
 export const INIT_SIZE = {
   'width': 100,


### PR DESCRIPTION
The reason for this change is because I have changed the canvas size in another branch. When you add a model on there, it goes under the sidebar ,and it can't be moved.