### PR TITLE
Updating comake services version

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/calebhsu/CoMake#readme",
   "dependencies": {
     "chai": "^3.5.0",
-    "comake-services": "^1.0.10",
+    "comake-services": "^1.0.17",
     "craftml": "^1.9.2-alpha-1",
     "firebase": "^3.6.8",
     "json": "^9.0.6",


### PR DESCRIPTION
This is to fix the comake services versioning, it was previously ^1.0.10, but current version is 1.0.17